### PR TITLE
Added responsive styles for mobile

### DIFF
--- a/src/components/timeline/timelineBlock.css
+++ b/src/components/timeline/timelineBlock.css
@@ -49,6 +49,10 @@
     padding-right: 1.4rem;
 }
 
+#timeline .timelineBlock:nth-child(even) .timelineArm svg {
+    transform: rotateY(180deg);
+}
+
 #timeline .timelineBlock:nth-child(odd) .timelineItem h1 {
     text-align: right;
 }

--- a/src/components/timeline/timelineBlock.css
+++ b/src/components/timeline/timelineBlock.css
@@ -144,3 +144,37 @@
               transform: translateX(0);
     }
   }
+
+@media only screen and (max-width: 1010px) {
+    #timeline {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        margin: 0 auto;
+    }
+    .timelineBlock {
+        display: flex;
+        width: 100%;
+        justify-content: center;
+        margin-top: 2em;
+    }
+    .timelineArm {
+        flex-direction: column;
+    }
+    .timelineArm svg {
+        display: none;
+    }
+    #timeline .timelineBlock:nth-child(odd), #timeline .timelineBlock:nth-child(even) {
+        left: initial;
+        flex-direction: column;
+    }
+    #timeline .timelineBlock:nth-child(odd) .timelineItem h1, #timeline .timelineBlock:nth-child(even) .timelineItem h1 {
+        text-align: center;
+    }
+    .timelineItem {
+        display: flex;
+        flex-direction: column;
+        /* justify-content: center; */
+        align-items: center;
+    }
+}


### PR DESCRIPTION
## Description
When the screen is less than 1010px, mobile styles take over: remove the timeline arms, center the dates and items along the timeline vertically, remove left and right item distinction.